### PR TITLE
fix: AsyncParallelBailHook bug

### DIFF
--- a/lib/AsyncParallelBailHook.js
+++ b/lib/AsyncParallelBailHook.js
@@ -14,7 +14,7 @@ class AsyncParallelBailHookCodeFactory extends HookCodeFactory {
 		code += "var _checkDone = () => {\n";
 		code += "for(var i = 0; i < _results.length; i++) {\n";
 		code += "var item = _results[i];\n";
-		code += "if(item === undefined) return false;\n";
+		code += "if(item === undefined) continue;\n";
 		code += "if(item.result !== undefined) {\n";
 		code += onResult("item.result");
 		code += "return true;\n";


### PR DESCRIPTION
AsyncParallelBailHook, use tapAsync/callAsync, it doesn't work as expected